### PR TITLE
subscription: document how to add an add-on subscription

### DIFF
--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -314,6 +314,8 @@ no content
 | **callCompletion** | boolean | false | ability to block the call until invoice and payment, if any, have been generated. (default: false)|
 | **callTimeoutSec** | long | false | when setting callCompletion=true, timeout in sec |
 
+When creating an add-on subscription, you need to specify the associated bundle in the body, either via its id or via its external key (but not both).
+
 **Returns**
 
 Returns a subscription object.


### PR DESCRIPTION
Notes:

* Technically, passing both parameters works if they are consistent. Not documented on purpose for simplicity.
* I haven't specified the parameters name (`bundleId` and `externalKey`) to be forward compatible (since `externalKey` has been renamed to `bundleExternalKey` in 0.22.x). Fields should be self-explanatory.
