### PR TITLE
Tenant docs update

### DIFF
--- a/source/includes/_tenant.md
+++ b/source/includes/_tenant.md
@@ -92,15 +92,24 @@ tenantApi.create_tenant(body, created_by='demo')
 
 ```javascript
 const api: killbill.TenantApi = new killbill.TenantApi(config);
+
 const tenant: killbill.Tenant = {apiKey: `api_key`, apiSecret: `api_secret`};
-const response: AxiosResponse<killbill.Tenant, any> = await api.createTenant(tenant, 'created-by');
+
+const response: AxiosResponse<killbill.Tenant, any> = await api.createTenant(tenant, 'created-by', 'reason', 'comment');
 ```
 
 ```php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
 $tenant = new Tenant();
-$tenant->setApiKey('php-tenant1');
-$tenant->setApiSecret('php-tenant1');
-$tenant = $client->getTenantApi()->createTenant($tenant, 'test_user', 'PHP_TEST', 'no comment');
+$tenant->setApiKey('demo_api_key');
+$tenant->setApiSecret('demo_api_secret');
+
+$tenant = $apiInstance->createTenant($tenant, $xKillbillCreatedBy, $keyName, $xKillbillReason, $xKillbillComment);
 ```
 
 **Request Body**
@@ -159,13 +168,18 @@ tenant = tenantApi.get_tenant(tenant_id='1a723c1a-9287-459f-9e40-eca9f0fd213e')
 
 ```javascript
 const api: killbill.TenantApi = new killbill.TenantApi(config);
+
 const id='9ab7db57-02a9-430c-bdfa-0a8c24d2e368'
+
 const response: AxiosResponse<killbill.Tenant, any> = await api.getTenant(id);
 ```
 
 ```php
+$apiInstance = $client->getTenantApi();
+
 $tenantid='9ab7db57-02a9-430c-bdfa-0a8c24d2e368';
-$tenantdata = $client->getTenantApi()->getTenant($tenantid);
+
+$tenantdata = $apiInstance->getTenant($tenantid);
 ```
 
 > Example Response:
@@ -228,13 +242,18 @@ tenant = tenantApi.get_tenant_by_api_key(api_key='bob')
 
 ```javascript
 const api: killbill.TenantApi = new killbill.TenantApi(config);
+
 const apiKey = 'bob'
+
 const response: AxiosResponse<killbill.Tenant, any> = await api.getTenantByApiKey(apiKey);
 ```
 
 ```php
+$apiInstance = $client->getTenantApi();
+
 $apikey='bob';
-$tenantdata = $client->getTenantApi()->getTenantByApiKey($apikey);
+
+$tenantdata = $apiInstance->getTenantByApiKey($apikey);
 ```
 
 > Example Response:
@@ -441,7 +460,7 @@ is used internally by the system to keep track of all the per-tenant configurati
 
 ### Add a per tenant user key/value
 
-This API adds a key-value pair to the tenant database. If the key already exists its value is replaced. The key is given as a path parameter.
+This API adds a key-value pair to the tenant database. If the key already exists, the new value is appended to the existing value. The key is given as a path parameter.
 
 **HTTP Request**
 
@@ -468,7 +487,7 @@ curl -v \
 import org.killbill.billing.client.api.gen.TenantApi;
 protected TenantApi tenantApi;
 
-String keyName = "demo_value";
+String keyName = "demo_key";
 String body = "demo_value";
 TenantKeyValue result = tenantApi.insertUserKeyValue(keyName, body, requestOptions);
 ```
@@ -478,10 +497,10 @@ user = "demo"
 reason = nil
 comment = nil
 
-key_name = "demo_value"
+key_name = "demo_key"
 key_value = "demo_value"
 
-KillBillClient::Model::Tenant.upload_tenant_user_key_value(key_name,
+tenant_key_value = KillBillClient::Model::Tenant.upload_tenant_user_key_value(key_name,
                                                            key_value,
                                                            user,
                                                            reason,
@@ -492,11 +511,32 @@ KillBillClient::Model::Tenant.upload_tenant_user_key_value(key_name,
 ```python
 tenantApi = killbill.api.TenantApi()
 
-key_name = 'demo_value'
+key_name = 'demo_key'
 body = 'demo_value'
 
 tenantApi.insert_user_key_value(key_name, body, created_by='demo')
 ```
+````javascript
+const key = 'demo_key';
+const value = 'demo_value';
+
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+api.insertUserKeyValue(value, key, 'created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$keyName = "demo_key";
+$body = "demo_value";
+
+$result = $apiInstance->insertUserKeyValue($body, $xKillbillCreatedBy, $keyName, $xKillbillReason, $xKillbillComment);
+````
 
 **Request Body**
 
@@ -526,31 +566,47 @@ curl -v \
     -H "X-Killbill-ApiKey: bob" \
     -H "X-Killbill-ApiSecret: lazar" \
     -H "Accept: application/json" \
-    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_value"
+    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_key"
 ```
 
 ```java
 import org.killbill.billing.client.api.gen.TenantApi;
 protected TenantApi tenantApi;
 
-String keyName = "demo_value";
+String keyName = "demo_key";
 
 TenantKeyValue result = tenantApi.getUserKeyValue(keyName, requestOptions);
 ```
 
 ```ruby
-key_name = "demo_value"
+key_name = "demo_key"
 
-KillBillClient::Model::Tenant.get_tenant_user_key_value(key_name, options)
+tenant_key_value = KillBillClient::Model::Tenant.get_tenant_user_key_value(key_name, options)
 ```
 
 ```python
 tenantApi = killbill.api.TenantApi()
 
-key_name = 'demo_value'
+key_name = 'demo_key'
 
-tenantApi.get_user_key_value(key_name)
+tenantKeyValue = tenantApi.get_user_key_value(key_name)
 ```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const key = 'demo_key'
+
+const response: AxiosResponse<killbill.TenantKeyValue, any> = await api.getUserKeyValue(key)
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$keyName = "demo_key";
+
+$result = $apiInstance->getUserKeyValue($keyName);
+````
 
 > Example Response:
 
@@ -603,14 +659,14 @@ curl -v \
     -H "X-Killbill-CreatedBy: demo" \
     -H "X-Killbill-Reason: demo" \
     -H "X-Killbill-Comment: demo" \
-    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_value"
+    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_key"
 ```
 
 ```java
 import org.killbill.billing.client.api.gen.TenantApi;
 protected TenantApi tenantApi;
 
-String keyName = "demo_value";
+String keyName = "demo_key";
 
 tenantApi.deleteUserKeyValue(keyName, requestOptions);
 ```
@@ -619,9 +675,9 @@ tenantApi.deleteUserKeyValue(keyName, requestOptions);
 user = "demo"
 reason = nil
 comment = nil
-key_value = "demo_value"
+key_name = "demo_key"
 
-KillBillClient::Model::Tenant.delete_tenant_user_key_value(key_value,
+KillBillClient::Model::Tenant.delete_tenant_user_key_value(key_name,
                                                            user,
                                                            reason,
                                                            comment,
@@ -631,10 +687,30 @@ KillBillClient::Model::Tenant.delete_tenant_user_key_value(key_value,
 ```python
 tenantApi = killbill.api.TenantApi()
 
-key_name = 'demo_value'
+key_name = 'demo_key'
 
 tenantApi.delete_user_key_value(key_name, created_by='demo')
 ```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const key = 'demo_key'
+
+api.deleteUserKeyValue(key, 'created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$keyName = "demo_key"; 
+
+$apiInstance->deleteUserKeyValue($keyName, $xKillbillCreatedBy, $xKillbillReason, $xKillbillComment);
+````
 
 **Query Parameters**
 
@@ -686,6 +762,14 @@ tenantApi = killbill.api.TenantApi()
 
 tenantApi.get_all_plugin_configuration(key_prefix='tenant_config')
 ```
+
+````javascript
+TODO
+````
+
+````php
+TODO
+````
 
 > Example Response:
 
@@ -752,7 +836,7 @@ curl -v \
 import org.killbill.billing.client.api.gen.TenantApi;
 protected TenantApi tenantApi;
 
-String body = "{\"org.killbill.invoice.sanitySafetyBoundEnabled\":\"false\"}";
+String body = "{'org.killbill.invoice.sanitySafetyBoundEnabled':'false'}";
 
 TenantKeyValue result = tenantApi.uploadPerTenantConfiguration(body, requestOptions);
 ```
@@ -767,6 +851,26 @@ body = '{"org.killbill.invoice.sanitySafetyBoundEnabled":"false"}'
 
 tenantApi.upload_per_tenant_configuration(body, created_by='demo')
 ```
+
+````javascript
+const body = '{"org.killbill.invoice.sanitySafetyBoundEnabled":"false"}';
+
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+api.uploadPerTenantConfiguration(body, 'created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$body = "{'org.killbill.invoice.sanitySafetyBoundEnabled':'false'}";
+
+$result = $apiInstance->uploadPerTenantConfiguration($body, $xKillbillCreatedBy, $xKillbillReason, $xKillbillComment);
+````
 
 **Request Body**
 
@@ -813,8 +917,20 @@ TODO
 ```python
 tenantApi = killbill.api.TenantApi()
 
-tenantApi.get_per_tenant_configuration()
+tenantKeyValue =  tenantApi.get_per_tenant_configuration()
 ```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const response: AxiosResponse<killbill.TenantKeyValue, any> = await api.getPerTenantConfiguration()
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$result = $apiInstance->getPerTenantConfiguration();
+````
 
 > Example Response:
 
@@ -874,6 +990,22 @@ tenantApi = killbill.api.TenantApi()
 
 tenantApi.delete_per_tenant_configuration(created_by='demo')
 ```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+api.deletePerTenantConfiguration('created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$apiInstance->deletePerTenantConfiguration($xKillbillCreatedBy, $xKillbillReason, $xKillbillComment);
+````
 
 **Query Parameters**
 

--- a/source/includes/_tenant.md
+++ b/source/includes/_tenant.md
@@ -1308,15 +1308,17 @@ The endpoints below allow you to override such state machines on a per-tenant le
 
 ### Add a per tenant payment state machine for a plugin
 
-Adds a per tenant key-value pair for the specified plugin. The plugin name is given as a path parameter. The key name is `PLUGIN_PAYMENT_STATE_MACHINE_*plugin*` where *plugin* is the plugin name. The API sets the value of this key, replacing any previous value.
+Adds a per tenant key-value pair for the specified plugin. The plugin name is given as a path parameter. The key name is `PLUGIN_PAYMENT_STATE_MACHINE_*plugin*` where *plugin* is the payment plugin name. The API sets the value of this key, replacing any previous value.
 
 The state machine is defined in an XML file. The complete XML file becomes the value of the key.
 
 **HTTP Request**
 
-Let's say we want to overwrite the default Kill Bill payment state machine for the payment plugin `demo_plugin`, and assuming `SimplePaymentStates.xml`is a valid payment state machine XML file, then the HTTP Request would be:
-
 `POST http://127.0.0.1:8080/1.0/kb/tenants/uploadPluginPaymentStateMachineConfig/{pluginName}`
+
+**Request Body**
+
+The request body can be specified as an XML string. Alternatively, the path of the XML file can be specified.
 
 > Example Request:
 
@@ -1339,8 +1341,8 @@ curl -v \
 import org.killbill.billing.client.api.gen.TenantApi;
 protected TenantApi tenantApi;
 
-String pluginName = "noop";
-String stateMachineConfig = getResourceBodyString("SimplePaymentStates.xml");
+String pluginName = "demo_plugin";
+String stateMachineConfig = "<xml>..</xml>";
 
 TenantKeyValue result = tenantApi.uploadPluginPaymentStateMachineConfig(pluginName,
                                                                         stateMachineConfig,
@@ -1355,10 +1357,32 @@ TODO
 tenantApi = killbill.api.TenantApi()
 
 plugin_name = 'demo_plugin'
-body = 'SimplePaymentStates.xml'
+body = '<xml>..</xml>'
 
 tenantApi.upload_plugin_payment_state_machine_config(plugin_name, body, created_by='demo')
 ```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const plugin_name = 'demo_plugin';
+const body = '<xml>..</xml>'
+
+api.uploadPluginPaymentStateMachineConfig(body, plugin_name, 'created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$pluginName = "demo_plugin";
+$body = "<xml>..</xml>";
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$result = $apiInstance->uploadPluginPaymentStateMachineConfig($body, $xKillbillCreatedBy, $pluginName, $xKillbillReason, $xKillbillComment);
+````
 
 **Query Parameters**
 
@@ -1370,7 +1394,7 @@ If successful, returns a status code of 201 and an empty body. In addition, a `L
 
 ### Retrieve a per tenant payment state machine for a plugin
 
-Retrieves the value for the appropriate payment state machine key for the specified plugin. If present, this value should be the complete XML file that defines the state machine.
+Retrieves the complete XML file corresponding to the payment state machine for the specified plugin if it exists.
 
 **HTTP Request**
 
@@ -1391,7 +1415,7 @@ curl -v \
 import org.killbill.billing.client.api.gen.TenantApi;
 protected TenantApi tenantApi;
 
-String pluginName = "noop";
+String pluginName = "demo_plugin";
 
 TenantKeyValue result = tenantApi.getPluginPaymentStateMachineConfig(pluginName, requestOptions);
 ```
@@ -1405,8 +1429,24 @@ tenantApi = killbill.api.TenantApi()
 
 plugin_name = 'demo_plugin'
 
-tenantApi.get_plugin_payment_state_machine_config(plugin_name)
+tenantKeyValue = tenantApi.get_plugin_payment_state_machine_config(plugin_name)
 ```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const plugin_name = 'demo_plugin';
+
+const response: AxiosResponse<killbill.TenantKeyValue, any> = await api.getPluginPaymentStateMachineConfig(plugin_name)
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$pluginName = "demo_plugin";
+
+$result = $apiInstance->getPluginPaymentStateMachineConfig($pluginName);
+````
 
 > Example Response:
 
@@ -1488,7 +1528,7 @@ None.
 
 **Response**
 
-If successful, returns a status code of 200 and a key value object for the key `PLUGIN_PAYMENT_STATE_MACHINE_*plugin*`. The value of this key should be the complete XML file that defines the payment state machine.
+If successful, returns a status code of 200 and a key value object for the key `PLUGIN_PAYMENT_STATE_MACHINE_*plugin*`. 
 
 ### Delete a per tenant payment state machine for a plugin
 
@@ -1516,7 +1556,7 @@ curl -v \
 import org.killbill.billing.client.api.gen.TenantApi;
 protected TenantApi tenantApi;
 
-String pluginName = "noop";
+String pluginName = "demo_plugin";
 
 tenantApi.deletePluginPaymentStateMachineConfig(pluginName, requestOptions);
 ```
@@ -1532,6 +1572,26 @@ plugin_name = 'demo_plugin'
 
 tenantApi.delete_plugin_payment_state_machine_config(plugin_name, created_by='demo')
 ```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const plugin_name = 'demo_plugin';
+
+api.deletePluginPaymentStateMachineConfig(plugin_name, 'created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$pluginName = "demo_plugin";
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$apiInstance->deletePluginPaymentStateMachineConfig($pluginName, $xKillbillCreatedBy, $xKillbillReason, $xKillbillComment);
+````
 
 **Query Parameters**
 

--- a/source/includes/_tenant.md
+++ b/source/includes/_tenant.md
@@ -281,6 +281,351 @@ $tenantdata = $apiInstance->getTenantByApiKey($apikey);
 
 If successful, returns a status code of 200 and a tenant resource object.  The `apiSecret` attribute is returned as `null`, since it cannot be retrieved.
 
+## Tenant Key-Value Pairs
+
+These endpoints provide a mechanism to register and manage `{key, value}` pairs for a given tenant. This functionality
+is used internally by the system to keep track of all the per-tenant configuration, including system properties, plugin configuration, and others discussed below. In addition, you can add *user* keys to keep track of additional information that may be desired. For example, some global setting that would be accessible for all plugins could be stored here.
+
+### Add a per tenant user key/value
+
+This API adds a key-value pair to the tenant database. If the key already exists, the new value is appended to the existing value. The key is given as a path parameter.
+
+**HTTP Request**
+
+`POST http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/{keyName}`
+
+> Example Request:
+
+```shell
+curl -v \
+    -X POST \
+    -u admin:password \
+    -H "X-Killbill-ApiKey: bob" \
+    -H "X-Killbill-ApiSecret: lazar" \
+    -H "Content-Type: text/plain" \
+    -H "Accept: application/json" \
+    -H "X-Killbill-CreatedBy: demo" \
+    -H "X-Killbill-Reason: demo" \
+    -H "X-Killbill-Comment: demo" \
+    -d "demo_value" \
+    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_key"
+```
+
+```java
+import org.killbill.billing.client.api.gen.TenantApi;
+protected TenantApi tenantApi;
+
+String keyName = "demo_key";
+String body = "demo_value";
+TenantKeyValue result = tenantApi.insertUserKeyValue(keyName, body, requestOptions);
+```
+
+```ruby
+user = "demo"
+reason = nil
+comment = nil
+
+key_name = "demo_key"
+key_value = "demo_value"
+
+tenant_key_value = KillBillClient::Model::Tenant.upload_tenant_user_key_value(key_name,
+                                                           key_value,
+                                                           user,
+                                                           reason,
+                                                           comment,
+                                                           options)
+```
+
+```python
+tenantApi = killbill.api.TenantApi()
+
+key_name = 'demo_key'
+body = 'demo_value'
+
+tenantApi.insert_user_key_value(key_name, body, created_by='demo')
+```
+````javascript
+const key = 'demo_key';
+const value = 'demo_value';
+
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+api.insertUserKeyValue(value, key, 'created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$keyName = "demo_key";
+$body = "demo_value";
+
+$result = $apiInstance->insertUserKeyValue($body, $xKillbillCreatedBy, $keyName, $xKillbillReason, $xKillbillComment);
+````
+
+**Request Body**
+
+The body contains a single string representing the value.
+
+**Query Parameters**
+
+None.
+
+**Response**
+
+If successful, returns a status code of 201 and an empty body. In addition, a `Location` item is returned in the header giving the URL for this key-value pair.
+
+### Retrieve a per tenant user key value
+
+Retrieves the value for a specified key, if it exists, from the tenant database. The key name is given as a path parameter.
+
+**HTTP Request**
+
+`GET http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/{keyName}`
+
+> Example Request:
+
+```shell
+curl -v \
+    -u admin:password \
+    -H "X-Killbill-ApiKey: bob" \
+    -H "X-Killbill-ApiSecret: lazar" \
+    -H "Accept: application/json" \
+    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_key"
+```
+
+```java
+import org.killbill.billing.client.api.gen.TenantApi;
+protected TenantApi tenantApi;
+
+String keyName = "demo_key";
+
+TenantKeyValue result = tenantApi.getUserKeyValue(keyName, requestOptions);
+```
+
+```ruby
+key_name = "demo_key"
+
+tenant_key_value = KillBillClient::Model::Tenant.get_tenant_user_key_value(key_name, options)
+```
+
+```python
+tenantApi = killbill.api.TenantApi()
+
+key_name = 'demo_key'
+
+tenantKeyValue = tenantApi.get_user_key_value(key_name)
+```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const key = 'demo_key'
+
+const response: AxiosResponse<killbill.TenantKeyValue, any> = await api.getUserKeyValue(key)
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$keyName = "demo_key";
+
+$result = $apiInstance->getUserKeyValue($keyName);
+````
+
+> Example Response:
+
+```json
+{
+  "key": "demo_value",
+  "values": [
+    "demo_value",
+    "demo_value"
+  ]
+}
+```
+
+
+**Query Parameters**
+
+None.
+
+**Response**
+
+If successful, returns a status code of 200 and a tenant key value object. The key value object includes the key name and a JSON array containing the value, if any, or a comma-separated list of values. For example:
+
+{
+"key": "MYKEY",
+"values": [
+"value1",
+"value2"
+]
+}
+
+
+If the key does not exist no error is signalled but the `values` list is empty.
+
+### Delete a per tenant user key/value
+
+Deletes a key and its value, if it exists, from the tenant database. The key is given as a path parameter.
+
+**HTTP Request**
+
+`DELETE http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/{keyName}`
+
+> Example Request:
+
+```shell
+curl -v \
+    -X DELETE \
+    -u admin:password \
+    -H "X-Killbill-ApiKey: bob" \
+    -H "X-Killbill-ApiSecret: lazar" \
+    -H "X-Killbill-CreatedBy: demo" \
+    -H "X-Killbill-Reason: demo" \
+    -H "X-Killbill-Comment: demo" \
+    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_key"
+```
+
+```java
+import org.killbill.billing.client.api.gen.TenantApi;
+protected TenantApi tenantApi;
+
+String keyName = "demo_key";
+
+tenantApi.deleteUserKeyValue(keyName, requestOptions);
+```
+
+```ruby
+user = "demo"
+reason = nil
+comment = nil
+key_name = "demo_key"
+
+KillBillClient::Model::Tenant.delete_tenant_user_key_value(key_name,
+                                                           user,
+                                                           reason,
+                                                           comment,
+                                                           options)
+```
+
+```python
+tenantApi = killbill.api.TenantApi()
+
+key_name = 'demo_key'
+
+tenantApi.delete_user_key_value(key_name, created_by='demo')
+```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const key = 'demo_key'
+
+api.deleteUserKeyValue(key, 'created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$keyName = "demo_key"; 
+
+$apiInstance->deleteUserKeyValue($keyName, $xKillbillCreatedBy, $xKillbillReason, $xKillbillComment);
+````
+
+**Query Parameters**
+
+None.
+
+**Returns**
+
+If successful, returns a status code of 204 and an empty body. No error is signalled if the key does not exist.
+
+### Retrieve per tenant keys and values based on a key prefix
+
+This API enables searching for existing keys based on a prefix of the key name. For example, a search string of "MYK" would match keys such as `MYKEY1`, `MYKEY2`, etc. The search string is given as a path parameter.
+
+
+**HTTP Request**
+
+`GET http://127.0.0.1:8080/1.0/kb/tenants/uploadPerTenantConfig/{keyPrefix}/search`
+
+
+> Example Request:
+
+
+```shell
+curl -v \
+    -u admin:password \
+    -H "X-Killbill-ApiKey: bob" \
+    -H "X-Killbill-ApiSecret: lazar" \
+    -H "Accept: application/json" \
+    "http://127.0.0.1:8080/1.0/kb/tenants/uploadPerTenantConfig/PER_TENANT/search"
+```
+
+```java
+import org.killbill.billing.client.api.gen.TenantApi;
+protected TenantApi tenantApi;
+
+String keyPrefix = "PER_TENANT";
+
+TenantKeyValues result = tenantApi.getAllPluginConfiguration(keyPrefix, requestOptions);
+```
+
+```ruby
+key_prefix = "PER_TENANT"
+
+tenant_key_values = KillBillClient::Model::Tenant.search_tenant_config(key_prefix, options)
+```
+
+```python
+tenantApi = killbill.api.TenantApi()
+
+tenantKeyValues = tenantApi.get_all_plugin_configuration(key_prefix='PER_TENANT')
+```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const keyPrefix = 'PER_TENANT'
+
+const response: AxiosResponse<killbill.TenantKeyValue, any> = await api.getAllPluginConfiguration(keyPrefix)
+````
+
+````php
+$keyPrefix = "PER_TENANT";
+
+$result = $apiInstance->getAllPluginConfiguration($keyPrefix);
+````
+
+> Example Response:
+
+```json
+{
+  "key": "PER_TENANT_CONFIG",
+  "values": [
+    "{org.killbill.invoice.sanitySafetyBoundEnabled:false}"
+  ]
+}
+```
+
+
+**Query Parameters**
+
+None.
+
+**Response**
+
+If successful, returns a status code of 200 and a tenant key value object containing the key and values for any keys that match the search string.
+
+
 ## Push Notifications
 
 Push notifications are a convenient way to get notified about events from the system.
@@ -492,346 +837,6 @@ None.
 
 If successful, returns a status code of 204 and an empty body.
 
-## Tenant Key-Value Pairs
-
-These endpoints provide a mechanism to register and manage `{key, value}` pairs for a given tenant. This functionality
-is used internally by the system to keep track of all the per-tenant configuration, including system properties, plugin configuration, and others discussed below. In addition, you can add *user* keys to keep track of additional information that may be desired. For example, some global setting that would be accessible for all plugins could be stored here.
-
-### Add a per tenant user key/value
-
-This API adds a key-value pair to the tenant database. If the key already exists, the new value is appended to the existing value. The key is given as a path parameter.
-
-**HTTP Request**
-
-`POST http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/{keyName}`
-
-> Example Request:
-
-```shell
-curl -v \
-    -X POST \
-    -u admin:password \
-    -H "X-Killbill-ApiKey: bob" \
-    -H "X-Killbill-ApiSecret: lazar" \
-    -H "Content-Type: text/plain" \
-    -H "Accept: application/json" \
-    -H "X-Killbill-CreatedBy: demo" \
-    -H "X-Killbill-Reason: demo" \
-    -H "X-Killbill-Comment: demo" \
-    -d "demo_value" \
-    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_key"
-```
-
-```java
-import org.killbill.billing.client.api.gen.TenantApi;
-protected TenantApi tenantApi;
-
-String keyName = "demo_key";
-String body = "demo_value";
-TenantKeyValue result = tenantApi.insertUserKeyValue(keyName, body, requestOptions);
-```
-
-```ruby
-user = "demo"
-reason = nil
-comment = nil
-
-key_name = "demo_key"
-key_value = "demo_value"
-
-tenant_key_value = KillBillClient::Model::Tenant.upload_tenant_user_key_value(key_name,
-                                                           key_value,
-                                                           user,
-                                                           reason,
-                                                           comment,
-                                                           options)
-```
-
-```python
-tenantApi = killbill.api.TenantApi()
-
-key_name = 'demo_key'
-body = 'demo_value'
-
-tenantApi.insert_user_key_value(key_name, body, created_by='demo')
-```
-````javascript
-const key = 'demo_key';
-const value = 'demo_value';
-
-const api: killbill.TenantApi = new killbill.TenantApi(config);
-
-api.insertUserKeyValue(value, key, 'created-by', 'reason', 'comment')
-````
-
-````php
-$apiInstance = $client->getTenantApi();
-
-$xKillbillCreatedBy = "user";
-$xKillbillReason = "reason";
-$xKillbillComment = "comment";
-
-$keyName = "demo_key";
-$body = "demo_value";
-
-$result = $apiInstance->insertUserKeyValue($body, $xKillbillCreatedBy, $keyName, $xKillbillReason, $xKillbillComment);
-````
-
-**Request Body**
-
-The body contains a single string representing the value.
-
-**Query Parameters**
-
-None.
-
-**Response**
-
-If successful, returns a status code of 201 and an empty body. In addition, a `Location` item is returned in the header giving the URL for this key-value pair.
-
-### Retrieve a per tenant user key value
-
-Retrieves the value for a specified key, if it exists, from the tenant database. The key name is given as a path parameter.
-
-**HTTP Request**
-
-`GET http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/{keyName}`
-
-> Example Request:
-
-```shell
-curl -v \
-    -u admin:password \
-    -H "X-Killbill-ApiKey: bob" \
-    -H "X-Killbill-ApiSecret: lazar" \
-    -H "Accept: application/json" \
-    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_key"
-```
-
-```java
-import org.killbill.billing.client.api.gen.TenantApi;
-protected TenantApi tenantApi;
-
-String keyName = "demo_key";
-
-TenantKeyValue result = tenantApi.getUserKeyValue(keyName, requestOptions);
-```
-
-```ruby
-key_name = "demo_key"
-
-tenant_key_value = KillBillClient::Model::Tenant.get_tenant_user_key_value(key_name, options)
-```
-
-```python
-tenantApi = killbill.api.TenantApi()
-
-key_name = 'demo_key'
-
-tenantKeyValue = tenantApi.get_user_key_value(key_name)
-```
-
-````javascript
-const api: killbill.TenantApi = new killbill.TenantApi(config);
-
-const key = 'demo_key'
-
-const response: AxiosResponse<killbill.TenantKeyValue, any> = await api.getUserKeyValue(key)
-````
-
-````php
-$apiInstance = $client->getTenantApi();
-
-$keyName = "demo_key";
-
-$result = $apiInstance->getUserKeyValue($keyName);
-````
-
-> Example Response:
-
-```json
-{
-  "key": "demo_value",
-  "values": [
-    "demo_value",
-    "demo_value"
-  ]
-}
-```
-
-
-**Query Parameters**
-
-None.
-
-**Response**
-
-If successful, returns a status code of 200 and a tenant key value object. The key value object includes the key name and a JSON array containing the value, if any, or a comma-separated list of values. For example:
-
-{
-  "key": "MYKEY",
-  "values": [
-    "value1",
-    "value2"
-  ]
-}
-
-
-If the key does not exist no error is signalled but the `values` list is empty.
-
-### Delete a per tenant user key/value
-
-Deletes a key and its value, if it exists, from the tenant database. The key is given as a path parameter.
-
-**HTTP Request**
-
-`DELETE http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/{keyName}`
-
-> Example Request:
-
-```shell
-curl -v \
-    -X DELETE \
-    -u admin:password \
-    -H "X-Killbill-ApiKey: bob" \
-    -H "X-Killbill-ApiSecret: lazar" \
-    -H "X-Killbill-CreatedBy: demo" \
-    -H "X-Killbill-Reason: demo" \
-    -H "X-Killbill-Comment: demo" \
-    "http://127.0.0.1:8080/1.0/kb/tenants/userKeyValue/demo_key"
-```
-
-```java
-import org.killbill.billing.client.api.gen.TenantApi;
-protected TenantApi tenantApi;
-
-String keyName = "demo_key";
-
-tenantApi.deleteUserKeyValue(keyName, requestOptions);
-```
-
-```ruby
-user = "demo"
-reason = nil
-comment = nil
-key_name = "demo_key"
-
-KillBillClient::Model::Tenant.delete_tenant_user_key_value(key_name,
-                                                           user,
-                                                           reason,
-                                                           comment,
-                                                           options)
-```
-
-```python
-tenantApi = killbill.api.TenantApi()
-
-key_name = 'demo_key'
-
-tenantApi.delete_user_key_value(key_name, created_by='demo')
-```
-
-````javascript
-const api: killbill.TenantApi = new killbill.TenantApi(config);
-
-const key = 'demo_key'
-
-api.deleteUserKeyValue(key, 'created-by', 'reason', 'comment')
-````
-
-````php
-$apiInstance = $client->getTenantApi();
-
-$xKillbillCreatedBy = "user";
-$xKillbillReason = "reason";
-$xKillbillComment = "comment";
-
-$keyName = "demo_key"; 
-
-$apiInstance->deleteUserKeyValue($keyName, $xKillbillCreatedBy, $xKillbillReason, $xKillbillComment);
-````
-
-**Query Parameters**
-
-None.
-
-**Returns**
-
-If successful, returns a status code of 204 and an empty body. No error is signalled if the key does not exist.
-
-### Retrieve per tenant keys and values based on a key prefix
-
-This API enables searching for existing keys based on a prefix of the key name. For example, a search string of "MYK" would match keys such as `MYKEY1`, `MYKEY2`, etc. The search string is given as a path parameter.
-
-
-**HTTP Request**
-
-`GET http://127.0.0.1:8080/1.0/kb/tenants/uploadPerTenantConfig/{keyPrefix}/search`
-
-
-> Example Request:
-
-
-```shell
-curl -v \
-    -u admin:password \
-    -H "X-Killbill-ApiKey: bob" \
-    -H "X-Killbill-ApiSecret: lazar" \
-    -H "Accept: application/json" \
-    "http://127.0.0.1:8080/1.0/kb/tenants/uploadPerTenantConfig/PER_TENANT/search"
-```
-
-```java
-import org.killbill.billing.client.api.gen.TenantApi;
-protected TenantApi tenantApi;
-
-String keyPrefix = "PER_TENANT";
-
-TenantKeyValues result = tenantApi.getAllPluginConfiguration(keyPrefix, requestOptions);
-```
-
-```ruby
-key_prefix = "PER_TENANT"
-
-KillBillClient::Model::Tenant.search_tenant_config(key_prefix, options)
-```
-
-```python
-tenantApi = killbill.api.TenantApi()
-
-tenantApi.get_all_plugin_configuration(key_prefix='tenant_config')
-```
-
-````javascript
-TODO
-````
-
-````php
-TODO
-````
-
-> Example Response:
-
-```json
-{
-  "key": "PER_TENANT_CONFIG",
-  "values": [
-    "{org.killbill.invoice.sanitySafetyBoundEnabled:false}"
-  ]
-}
-```
-
-
-**Query Parameters**
-
-None.
-
-**Response**
-
-If successful, returns a status code of 200 and a tenant key value object containing the key and values for any keys that match the search string.
-
-
-
 
 ## System Properties Configuration
 
@@ -846,8 +851,7 @@ This API is used to set the value of specific system properties, overriding the 
 
 For example, in order to disable the invoice safety bound mechanism on a per-tenant level, this API could be used to set the per-tenant system property `org.killbill.invoice.sanitySafetyBoundEnabled` to false.
 
-The API sets the value of the "PER_TENANT_CONFIG" key, replacing any previous value.
-
+The API inserts a key-value pair corresponding to the tenant where key name is `PER_TENANT_CONFIG` and value is the system property to be set. It replaces any previous value.
 
 **HTTP Request**
 
@@ -867,7 +871,7 @@ curl -v \
     -H "X-Killbill-CreatedBy: demo" \
     -H "X-Killbill-Reason: demo" \
     -H "X-Killbill-Comment: demo" \
-    -d "{"org.killbill.invoice.sanitySafetyBoundEnabled":"false"}" \
+    -d '{"org.killbill.invoice.sanitySafetyBoundEnabled":"false"}' \
     "http://127.0.0.1:8080/1.0/kb/tenants/uploadPerTenantConfig"
 ```
 
@@ -1069,7 +1073,7 @@ As with the system properties configuration, this is actually a special case of 
 
 ### Add a per tenant configuration for a plugin
 
-Adds a per tenant key-value pair for the specified plugin. The plugin name is given as a path parameter. The API internally inserts a key-value pair with key name=`PLUGIN_CONFIG_*plugin*` where *plugin* is the plugin name. It replaces any previous value.
+Adds a per tenant key-value pair for the specified plugin. The plugin name is given as a path parameter. The API internally inserts a key-value pair corresponding to the tenant with key name=`PLUGIN_CONFIG_*plugin*` where *plugin* is the plugin name. It replaces any previous value.
 
 The value string uploaded is plugin dependent but typically consists of key/value properties,
 or well formatted yml or a properties file.

--- a/source/includes/_tenant.md
+++ b/source/includes/_tenant.md
@@ -294,7 +294,7 @@ See push notification documentation [here](https://docs.killbill.io/latest/push_
 
 ### Register a push notification
 
-Register a callback URL for this tenant for push notifications.The key name is PUSH_NOTIFICATION_CB. The API sets the value of this key, replacing any previous value.
+Register a callback URL for this tenant for push notifications. Inserts a key-value pair corresponding to the tenant where key name is `PUSH_NOTIFICATION_CB` and value is the URL of the push notification handler. The API sets the value of this key, replacing any previous value. 
 
 **HTTP Request**
 
@@ -334,6 +334,22 @@ tenantApi = killbill.api.TenantApi()
 
 tenantApi.register_push_notification_callback(created_by='demo', cb='http://demo/callmeback')
 ```
+
+````javascript
+TODO
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$cb = "http://demo/callmeback";
+
+$result = $apiInstance->registerPushNotificationCallback($xKillbillCreatedBy, $cb, $xKillbillReason, $xKillbillComment);
+````
 
 **Query Parameters**
 
@@ -381,6 +397,18 @@ tenantApi = killbill.api.TenantApi()
 tenantApi.get_push_notification_callbacks()
 ```
 
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+const response: AxiosResponse<killbill.TenantKeyValue, any> = await api.getPushNotificationCallbacks()
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$result = $apiInstance->getPushNotificationCallbacks();
+````
+
 > Example Response:
 
 ```json
@@ -399,12 +427,7 @@ None.
 
 **Response**
 
-If successful, returns a status code of 200 and a body containing a key-value object as follows:
-
-{
-  "key": "PUSH_NOTIFICATION_CB",
-  "values": list containing the callback URL, if any
-}
+If successful, returns a status code of 200 and a tenant key value object for the key PUSH_NOTIFICATION_CB.
 
 ### Delete a registered push notification
 
@@ -444,6 +467,22 @@ tenantApi = killbill.api.TenantApi()
 
 tenantApi.delete_push_notification_callbacks(created_by='demo')
 ```
+
+````javascript
+const api: killbill.TenantApi = new killbill.TenantApi(config);
+
+api.deletePushNotificationCallbacks('created-by', 'reason', 'comment')
+````
+
+````php
+$apiInstance = $client->getTenantApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$apiInstance->deletePushNotificationCallbacks($xKillbillCreatedBy, $xKillbillReason, $xKillbillComment);
+````
 
 **Query Parameters**
 


### PR DESCRIPTION
Includes the following changes in the Tenants section:

1. PHP/Javascript docs for all endpoints
2. Corrections to Python/Java/Ruby code snippets as required
3. Overall corrections to endpoint descriptions/Request body/Response as required
4. Moved `Tenant Key/Value` section above `Push Notifications` section

The following is yet to be done:

1. Ruby code snippets are not added for some endpoints. The Ruby client does not include the code for these endpoints. I have filed https://github.com/killbill/killbill-client-ruby/issues/88 to track this.
2. The Javascript code snippet is not added for the Register Push Notification endpoint due to an issue in the client code. I have filed https://github.com/killbill/killbill-client-js/issues/146 to track this.
