### PR TITLE
Subscriptions blocking state custom fields

### DIFF
--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -1986,7 +1986,7 @@ If successful, returns a status code of 204 and an empty body.
 
 ### Remove custom fields from subscription
 
-Delete one or more custom fields from a subscription
+Delete one or more custom fields from a subscription. It accepts query parameters corresponding to the custom field ids to be deleted. if no query parameters are specified, it deletes all the custom fields corresponding to the subscription.
 
 
 **HTTP Request** 
@@ -2075,8 +2075,8 @@ $apiInstance->deleteSubscriptionCustomFields($subscriptionId, $xKillbillCreatedB
 **Query Parameters**
 
 | Name | Type | Required | Default | Description |
-| ---- | -----| -------- | ------- | ----------- | 
-| **customField** | string | yes | none | Custom field object ID that should be deleted. Multiple custom fields can be deleted by specifying a separate **customField** parameter corresponding to each field |
+| ---- | -----|----------| ------- | ----------- | 
+| **customField** | string | no       | none | Custom field object ID that should be deleted. Multiple custom fields can be deleted by specifying a separate **customField** parameter corresponding to each field |
 
 **Response**
 

--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -1587,6 +1587,30 @@ subscriptionApi.add_subscription_blocking_state(subscription_id,
                                                 comment='comment')
 ```
 
+````javascript
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$blockingState = new BlockingState();
+$blockingState -> setStateName('STATE1');
+$blockingState -> setService('ServiceStateService1');
+$blockingState -> setIsBlockChange(true);
+$blockingState -> setIsBlockBilling(true);
+$blockingState -> setIsBlockEntitlement(true);
+
+$subscriptionId = "3f4a2efd-a8c1-4f85-9266-32bd6f7113ba";
+$requestedDate = new DateTime("2023-10-20");
+$pluginProperty = array("pluginProperty_example");
+
+$result = $apiInstance->addSubscriptionBlockingState($blockingState, $xKillbillCreatedBy, $subscriptionId, $xKillbillReason, $xKillbillComment, $requestedDate, $pluginProperty);
+````
+
 **Request Body**
 
 A [blocking state resource](account-blocking-state-resource) representing the intended new blocking state.
@@ -1696,6 +1720,26 @@ subscriptionApi.create_subscription_custom_fields(subscription_id,
                                                   comment='comment')
 ```
 
+````javascript
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$subscriptionId = "3f4a2efd-a8c1-4f85-9266-32bd6f7113ba";
+
+$customField = new CustomField();
+$customField -> setName('Test Custom Field');
+$customField -> setValue('test_value');
+$body = array($customField);
+
+$apiInstance->createSubscriptionCustomFields($body, $xKillbillCreatedBy, $subscriptionId, $xKillbillReason, $xKillbillComment);
+````
+
 **Request Body**
 
 A list of objects giving the name and value of the custom field, or fields, to be added. For example:
@@ -1760,6 +1804,18 @@ subscription_id = '33aa2952-cea2-4cad-900a-9731c1042e54'
 
 fields = subscriptionApi.get_subscription_custom_fields(subscription_id)
 ```
+
+````javascript
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$subscriptionId = "3f4a2efd-a8c1-4f85-9266-32bd6f7113ba";
+$audit = "NONE";
+
+$result = $apiInstance->getSubscriptionCustomFields($subscriptionId, $audit);
+````
 
 > Example Response:
 
@@ -1864,6 +1920,26 @@ subscriptionApi.modify_subscription_custom_fields(subscription_id,
                                                   comment='comment')
 ```
 
+````javascript
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$subscriptionId = "3f4a2efd-a8c1-4f85-9266-32bd6f7113ba";
+
+$customField = new CustomField();
+$customField -> setCustomFieldId('73e399fe-efaa-4f05-a5fe-08f10608c345');
+$customField -> setValue('new_value');
+$body = array($customField);
+
+$apiInstance->modifySubscriptionCustomFields($body, $xKillbillCreatedBy, $subscriptionId, $xKillbillReason, $xKillbillComment);
+````
+
 **Request Body**
 
 A list of objects specifying the id and the new value for the custom fields to be modified. For example:
@@ -1943,6 +2019,22 @@ subscriptionApi.delete_subscription_custom_fields(subscription_id=subscription_i
                                                   reason='reason',
                                                   comment='comment')
 ```
+
+````javascript
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$subscriptionId = "3f4a2efd-a8c1-4f85-9266-32bd6f7113ba";
+$customFields = array("73e399fe-efaa-4f05-a5fe-08f10608c345");
+
+$apiInstance->deleteSubscriptionCustomFields($subscriptionId, $xKillbillCreatedBy, $customFields, $xKillbillReason, $xKillbillComment);
+````
 
 **Query Parameters**
 

--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -1578,12 +1578,13 @@ body = BlockingState(state_name='STATE1',
                      is_block_change=False,
                      is_block_entitlement=False,
                      is_block_billing=False)
+subscription_id = '33aa2952-cea2-4cad-900a-9731c1042e54'
 
 subscriptionApi.add_subscription_blocking_state(subscription_id,
                                                 body,
-                                                created_by,
-                                                api_key,
-                                                api_secret)
+                                                created_by='demo',
+                                                reason='reason',
+                                                comment='comment')
 ```
 
 **Request Body**
@@ -1685,14 +1686,14 @@ subscription.add_custom_field(custom_field,
 
 ```python
 subscriptionApi = killbill.api.SubscriptionApi()
-subscription_id = '4927c1a2-3959-4f71-98e7-ce3ba19c92ac'
+subscription_id = '33aa2952-cea2-4cad-900a-9731c1042e54'
 body = CustomField(name='Test Custom Field', value='test_value')
 
 subscriptionApi.create_subscription_custom_fields(subscription_id,
                                                   [body],
-                                                  created_by,
-                                                  api_key,
-                                                  api_secret)
+                                                  created_by='demo',
+                                                  reason='reason',
+                                                  comment='comment')
 ```
 
 **Request Body**
@@ -1755,11 +1756,9 @@ fields = subscription.custom_fields(audit, options)
 
 ```python
 subscriptionApi = killbill.api.SubscriptionApi()
-subscription_id = '642ee0ac-972b-4cdf-b9ae-ab8f9bb9bc05'
+subscription_id = '33aa2952-cea2-4cad-900a-9731c1042e54'
 
-subscriptionApi.get_subscription_custom_fields(subscription_id,
-                                               api_key,
-                                               api_secret)
+fields = subscriptionApi.get_subscription_custom_fields(subscription_id)
 ```
 
 > Example Response:
@@ -1853,17 +1852,16 @@ subscription.modify_custom_field(custom_field,
 
 ```python
 subscriptionApi = killbill.api.SubscriptionApi()
-subscription_id = '4927c1a2-3959-4f71-98e7-ce3ba19c92ac'
-custom_field_id = '7fb3dde7-0911-4477-99e3-69d142509bb9'
-body = CustomField(custom_field_id=custom_field_id, 
-                   name='Test Custom Field', 
-                   value='test_value')
+subscription_id = '33aa2952-cea2-4cad-900a-9731c1042e54'
+custom_field_id = '3a26be42-a153-4894-ac3d-93ad2e38e05b'
+body = CustomField(custom_field_id=custom_field_id,
+                   value='modified_value')
 
 subscriptionApi.modify_subscription_custom_fields(subscription_id,
                                                   [body],
-                                                  created_by,
-                                                  api_key,
-                                                  api_secret)
+                                                  created_by='demo',
+                                                  reason='reason',
+                                                  comment='comment')
 ```
 
 **Request Body**
@@ -1935,12 +1933,15 @@ subscription.remove_custom_field(custom_field_id,
 
 ```python
 subscriptionApi = killbill.api.SubscriptionApi()
-subscription_id = '4927c1a2-3959-4f71-98e7-ce3ba19c92ac'
+subscription_id = 'e5254822-680f-4720-b5e1-a7146cefb904'
 
-subscriptionApi.delete_subscription_custom_fields(subscription_id,
-                                                  created_by,
-                                                  api_key,
-                                                  api_secret)
+custom_fields = ['194bcfc8-340f-4592-acd2-ffc1fc461e96']
+
+subscriptionApi.delete_subscription_custom_fields(subscription_id=subscription_id,
+                                                  created_by='demo',
+                                                  custom_field=custom_fields,
+                                                  reason='reason',
+                                                  comment='comment')
 ```
 
 **Query Parameters**

--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -1588,6 +1588,12 @@ subscriptionApi.add_subscription_blocking_state(subscription_id,
 ```
 
 ````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const blockingState: BlockingState = {stateName: "STATE1", service: "ServiceStateService", isBlockChange: true, isBlockEntitlement: false, isBlockBilling: false};
+const subscriptionId = 'b6000207-42fd-40ea-9c8e-297d9adc1574';
+
+api.addSubscriptionBlockingState(blockingState, subscriptionId, 'created_by');
 ````
 
 ````php
@@ -1721,6 +1727,14 @@ subscriptionApi.create_subscription_custom_fields(subscription_id,
 ```
 
 ````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const subscriptionId = 'b6000207-42fd-40ea-9c8e-297d9adc1574';
+
+const customField: CustomField = {name: "Test Custom Field", value: "test_value"};
+const customFields = [customField];
+
+api.createSubscriptionCustomFields(customFields, subscriptionId, 'created_by');
 ````
 
 ````php
@@ -1806,6 +1820,12 @@ fields = subscriptionApi.get_subscription_custom_fields(subscription_id)
 ```
 
 ````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const subscriptionId = 'e5254822-680f-4720-b5e1-a7146cefb904';
+const audit = 'NONE';
+
+const response: AxiosResponse<killbill.CustomField[], any> = await api.getSubscriptionCustomFields(subscriptionId, audit, 'created_by');
 ````
 
 ````php
@@ -1921,6 +1941,14 @@ subscriptionApi.modify_subscription_custom_fields(subscription_id,
 ```
 
 ````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const subscriptionId = 'b6000207-42fd-40ea-9c8e-297d9adc1574';
+
+const customField: CustomField = {customFieldId: "d8f2e80d-9fd8-48e7-b564-a541a0a7621d", value: "new_value"};
+const customFields = [customField];
+
+api.modifySubscriptionCustomFields(customFields, subscriptionId, 'created_by');
 ````
 
 ````php
@@ -2021,6 +2049,14 @@ subscriptionApi.delete_subscription_custom_fields(subscription_id=subscription_i
 ```
 
 ````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const subscriptionId = 'b6000207-42fd-40ea-9c8e-297d9adc1574';
+
+const customField = 'd8f2e80d-9fd8-48e7-b564-a541a0a7621d';
+const customFields = [customField];
+
+api.deleteSubscriptionCustomFields(subscriptionId, 'created_by', customFields);
 ````
 
 ````php

--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -1584,7 +1584,7 @@ subscriptionApi.add_subscription_blocking_state(subscription_id,
 
 **Request Body**
 
-A blocking state resource representing the intended new blocking state. For example,
+A [blocking state resource](account-blocking-state-resource) representing the intended new blocking state.
 
 ```
 {
@@ -1607,7 +1607,7 @@ A blocking state resource representing the intended new blocking state. For exam
 
 **Response**
 
-If successful, returns a status code of 201 and an empty body.
+If successful, returns a status code of 201 and an empty body. In addition, a `Location` header is returned which contains the URL to retrieve the subscription blocking states for the account.
 
 
 ## Custom Fields
@@ -1633,8 +1633,6 @@ curl -v \
     -H "Content-Type: application/json" \
     -H "X-Killbill-CreatedBy: demo" \
     -d '[{ 
-            "objectId": "77e23878-8b9d-403b-bf31-93003e125712",
-            "objectType": "SUBSCRIPTION",
             "name": "Test Custom Field",
             "value": "test_value"
     }]' \
@@ -1809,10 +1807,10 @@ import org.killbill.billing.client.api.gen.SubscriptionApi;
 protected SubscriptionApi subscriptionApi;
 
 UUID subscriptionId = UUID.fromString("cca08349-8b26-41c7-bfcc-2e3cf70a0f28");
-UUID customFieldsId = UUID.fromString("9913e0f6-b5ef-498b-ac47-60e1626eba8f");
+UUID customFieldId = UUID.fromString("9913e0f6-b5ef-498b-ac47-60e1626eba8f");
 
 CustomField customFieldModified = new CustomField();
-customFieldModified.setCustomFieldId(customFieldsId);
+customFieldModified.setCustomFieldId(customFieldId);
 customFieldModified.setValue("NewValue");
 CustomFields customFields = new CustomFields();
 customFields.add(customFieldModified);

--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -1545,6 +1545,10 @@ BlockingStates result = subscriptionApi.addSubscriptionBlockingState(subscriptio
 ```
 
 ```ruby
+user = "demo"
+reason = nil
+comment = nil
+
 subscription = KillBillClient::Model::Subscription.new
 subscription.subscription_id = "161692a4-c293-410c-a92f-939c5e3dcba7"
 
@@ -1661,12 +1665,18 @@ subscriptionApi.createSubscriptionCustomFields(subscriptionId,
 ```
 
 ```ruby
+user = "demo"
+reason = nil
+comment = nil
+
+subscription = KillBillClient::Model::Subscription.new
+subscription.subscription_id = "2207150d-0652-43eb-abbe-2cbd0092b744"
+
 custom_field = KillBillClient::Model::CustomFieldAttributes.new
-custom_field.object_type = 'SUBSCRIPTION'
 custom_field.name = 'Test Custom Field'
 custom_field.value = 'test_value'
 
-subscription.add_custom_field(custom_field, 
+subscription.add_custom_field(custom_field,
                               user,
                               reason,
                               comment,
@@ -1736,9 +1746,11 @@ List<CustomField> customFields = subscriptionApi.getSubscriptionCustomFields(sub
 ```
 
 ```ruby
-audit = 'NONE'
+subscription = KillBillClient::Model::Subscription.new
+subscription.subscription_id = "2207150d-0652-43eb-abbe-2cbd0092b744"
 
-subscription.custom_fields(audit, options)
+audit = 'NONE'
+fields = subscription.custom_fields(audit, options)
 ```
 
 ```python
@@ -1821,14 +1833,21 @@ subscriptionApi.modifySubscriptionCustomFields(subscriptionId,
 ```
 
 ```ruby
-custom_field.custom_field_id = '7fb3dde7-0911-4477-99e3-69d142509bb9'
-custom_field.name = 'Test Modify'
+user = "demo"
+reason = nil
+comment = nil
+
+subscription = KillBillClient::Model::Subscription.new
+subscription.subscription_id = "2207150d-0652-43eb-abbe-2cbd0092b744"
+
+custom_field = KillBillClient::Model::CustomFieldAttributes.new
+custom_field.custom_field_id = 'a04adaca-78a4-41fe-b512-a8d620aad456'
 custom_field.value = 'test_modify_value'
 
-subscription.modify_custom_field(custom_field,                                                                                            
-                                 user, 
+subscription.modify_custom_field(custom_field,
+                                 user,
                                  reason,
-                                 comment, 
+                                 comment,
                                  options)
 ```
 
@@ -1898,12 +1917,19 @@ subscriptionApi.deleteSubscriptionCustomFields(subscriptionId,
 ```
 
 ```ruby
-custom_field_id = custom_field.id
+user = "demo"
+reason = nil
+comment = nil
 
-subscription.remove_custom_field(custom_field_id,                                                                                            
-                                 user, 
+subscription = KillBillClient::Model::Subscription.new
+subscription.subscription_id = "2207150d-0652-43eb-abbe-2cbd0092b744"
+
+custom_field_id = 'a04adaca-78a4-41fe-b512-a8d620aad456'
+
+subscription.remove_custom_field(custom_field_id,
+                                 user,
                                  reason,
-                                 comment, 
+                                 comment,
                                  options)
 ```
 


### PR DESCRIPTION
Includes the following for the subscription Blocking State/Custom fields endpoints:
1. Corrections to endpoint descriptions/request/response/query parameters
2. Corrections to Shell, Java, Ruby, Python code
3. JS/PHP code snippets