### PR TITLE
Subsctipions tags audit logs

### DIFF
--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -1973,7 +1973,14 @@ subscriptionApi.createSubscriptionTags(subscriptionId,
 ```
 
 ```ruby
-tag_name = 'foo'
+user = "demo"
+reason = nil
+comment = nil
+
+subscription = KillBillClient::Model::Subscription.new
+subscription.subscription_id = "92820d1c-1d4c-46eb-9010-26b0626a1927"
+
+tag_name = 'good_sub'
 
 subscription.add_tag(tag_name,
                      user,
@@ -1984,14 +1991,14 @@ subscription.add_tag(tag_name,
 
 ```python
 subscriptionApi = killbill.api.SubscriptionApi()
-subscription_id = '28af3cb9-275b-4ac4-a55d-a0536e479069'
-tag = ["353752dd-9041-4450-b782-a8bb03a923c8"]
+subscription_id = '92820d1c-1d4c-46eb-9010-26b0626a1927'
+tagDefIds = ['30363fe5-310d-4446-b000-d7bb6e6662e2']
 
 subscriptionApi.create_subscription_tags(subscription_id,
-                                         tag,
-                                         created_by,
-                                         api_key,
-                                         api_secret)
+                                         tagDefIds,
+                                         created_by='demo',
+                                         reason='reason',
+                                         comment='comment')
 ```
 
 **Request Body**
@@ -2041,21 +2048,22 @@ List<Tag> tags = subscriptionApi.getSubscriptionTags(subscriptionId,
 ```
 
 ```ruby
+subscription = KillBillClient::Model::Subscription.new
+subscription.subscription_id = "92820d1c-1d4c-46eb-9010-26b0626a1927"
+
 included_deleted = false
 audit = 'NONE'
 
-subscription.tags(included_deleted,
+tags = subscription.tags(included_deleted,
                   audit,
                   options)
 ```
 
 ```python
 subscriptionApi = killbill.api.SubscriptionApi()
-subscription_id = 'f5bb14ed-c6e8-4895-8d4e-34422e12cdfa'
+subscription_id = '92820d1c-1d4c-46eb-9010-26b0626a1927'
 
-subscriptionApi.get_subscription_tags(subscription_id,
-                                      api_key,
-                                      api_secret)
+tags = subscriptionApi.get_subscription_tags(subscription_id)
 ```
 
 > Example Response:
@@ -2118,7 +2126,14 @@ subscriptionApi.deleteSubscriptionTags(subscriptionId, List.of(tagDefinitionId),
 ```
 
 ```ruby
-tag_name = 'foo'
+user = "demo"
+reason = nil
+comment = nil
+
+subscription = KillBillClient::Model::Subscription.new
+subscription.subscription_id = "92820d1c-1d4c-46eb-9010-26b0626a1927"
+
+tag_name = 'good_sub'
 
 subscription.remove_tag(tag_name,
                         user,
@@ -2129,14 +2144,14 @@ subscription.remove_tag(tag_name,
 
 ```python
 subscriptionApi = killbill.api.SubscriptionApi()
-subscription_id = 'f5bb14ed-c6e8-4895-8d4e-34422e12cdfa'
-tag = ["353752dd-9041-4450-b782-a8bb03a923c8"]
+subscription_id = '92820d1c-1d4c-46eb-9010-26b0626a1927'
+tagDefIds = ['30363fe5-310d-4446-b000-d7bb6e6662e2']
 
 subscriptionApi.delete_subscription_tags(subscription_id,
-                                         created_by,
-                                         api_key,
-                                         api_secret,
-                                         tag_def=tag)
+                                         created_by='demo',
+                                         reason='reason',
+                                         comment='comment',
+                                         tag_def=tagDefIds)
 ```
 
 **Query Parameters**
@@ -2191,6 +2206,17 @@ UUID subscriptionId = UUID.fromString("bc9b98e8-7497-4330-aa42-1fbc71a3d19c");
 		
 List<AuditLog> auditLog = subscriptionApi.getSubscriptionAuditLogsWithHistory(subscriptionId, requestOptions);
 ```
+
+````ruby
+TODO
+````
+
+````python
+subscriptionApi = killbill.api.SubscriptionApi()
+subscription_id = '92820d1c-1d4c-46eb-9010-26b0626a1927'
+
+auditlogs = subscriptionApi.get_subscription_audit_logs_with_history(subscription_id)
+````
 
 > Example Response:
 
@@ -2298,6 +2324,17 @@ UUID subscriptionEventId = UUID.fromString("b4b6f990-4456-4009-9e6c-9825a99a1f25
 		
 List<AuditLog> eventAuditLog = subscriptionApi.getSubscriptionEventAuditLogsWithHistory(subscriptionEventId, requestOptions);
 ```
+
+````ruby
+TODO
+````
+
+````python
+subscriptionApi = killbill.api.SubscriptionApi()
+event_id = 'dc283026-5be0-4e47-8190-b62fb0c9e357'
+
+auditlogs = subscriptionApi.get_subscription_event_audit_logs_with_history(event_id)
+````
 
 > Example Response:
 

--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -2001,6 +2001,29 @@ subscriptionApi.create_subscription_tags(subscription_id,
                                          comment='comment')
 ```
 
+````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const subscriptionId = '92820d1c-1d4c-46eb-9010-26b0626a1927';
+
+const tagDefIds = ['06d991f7-f06a-4e45-80d2-c3b44a97f8bc'];
+
+api.createSubscriptionTags(tagDefIds, subscriptionId, 'created_by');
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$subscriptionId = "92820d1c-1d4c-46eb-9010-26b0626a1927";
+$tagDefIds = array("30363fe5-310d-4446-b000-d7bb6e6662e2");
+
+$apiInstance->createSubscriptionTags($tagDefIds, $xKillbillCreatedBy, $subscriptionId, $xKillbillReason, $xKillbillComment);
+````
+
 **Request Body**
 
 A JSON array containing one or more strings giving the UUID of tag definitions for the user tags to be added.
@@ -2065,6 +2088,26 @@ subscription_id = '92820d1c-1d4c-46eb-9010-26b0626a1927'
 
 tags = subscriptionApi.get_subscription_tags(subscription_id)
 ```
+
+````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const subscriptionId = '92820d1c-1d4c-46eb-9010-26b0626a1927';
+const includeDeleted = false;
+const audit = 'NONE';
+
+const response: AxiosResponse<killbill.Tag[], any> = await api.getSubscriptionTags(subscriptionId, includeDeleted, audit);
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$subscriptionId = "92820d1c-1d4c-46eb-9010-26b0626a1927";
+$includedDeleted = false;
+$audit = "NONE";
+
+$result = $apiInstance->getSubscriptionTags($subscriptionId, $includedDeleted, $audit);
+````
 
 > Example Response:
 
@@ -2154,6 +2197,29 @@ subscriptionApi.delete_subscription_tags(subscription_id,
                                          tag_def=tagDefIds)
 ```
 
+````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const subscriptionId = '92820d1c-1d4c-46eb-9010-26b0626a1927';
+
+const tagDefIds = ['06d991f7-f06a-4e45-80d2-c3b44a97f8bc'];
+
+api.deleteSubscriptionTags(subscriptionId, 'created_by', tagDefIds);
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$xKillbillCreatedBy = "user";
+$xKillbillReason = "reason";
+$xKillbillComment = "comment";
+
+$subscriptionId = "92820d1c-1d4c-46eb-9010-26b0626a1927";
+$tagDefIds = array("30363fe5-310d-4446-b000-d7bb6e6662e2");
+
+$apiInstance->deleteSubscriptionTags($subscriptionId, $xKillbillCreatedBy, $tagDefIds, $xKillbillReason, $xKillbillComment);
+````
+
 **Query Parameters**
 
 | Name | Type   | Required | Default | Description |
@@ -2216,6 +2282,22 @@ subscriptionApi = killbill.api.SubscriptionApi()
 subscription_id = '92820d1c-1d4c-46eb-9010-26b0626a1927'
 
 auditlogs = subscriptionApi.get_subscription_audit_logs_with_history(subscription_id)
+````
+
+````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const subscriptionId = '92820d1c-1d4c-46eb-9010-26b0626a1927';
+
+const response: AxiosResponse<killbill.Tag[], any> = await api.getSubscriptionAuditLogsWithHistory(subscriptionId);
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$subscriptionId = "92820d1c-1d4c-46eb-9010-26b0626a1927";
+
+$result = $apiInstance->getSubscriptionAuditLogsWithHistory($subscriptionId);
 ````
 
 > Example Response:
@@ -2334,6 +2416,22 @@ subscriptionApi = killbill.api.SubscriptionApi()
 event_id = 'dc283026-5be0-4e47-8190-b62fb0c9e357'
 
 auditlogs = subscriptionApi.get_subscription_event_audit_logs_with_history(event_id)
+````
+
+````javascript
+const api: killbill.SubscriptionApi = new killbill.SubscriptionApi(config);
+
+const eventId = 'dc283026-5be0-4e47-8190-b62fb0c9e357';
+
+const response: AxiosResponse<killbill.Tag[], any> = await api.getSubscriptionEventAuditLogsWithHistory(eventId);
+````
+
+````php
+$apiInstance = $client->getSubscriptionApi();
+
+$eventId = "dc283026-5be0-4e47-8190-b62fb0c9e357";
+
+$result = $apiInstance->getSubscriptionEventAuditLogsWithHistory($eventId);
 ````
 
 > Example Response:


### PR DESCRIPTION
Includes the following for the subscription tags and audit logs endpoints:
1. Corrections to endpoint descriptions/request/response/query parameters
2. Corrections to Shell, Java, Ruby, and Python code
3. JS/PHP code snippets