### PR TITLE
Show 'plaintext' example response

### DIFF
--- a/source/includes/_invoice.md
+++ b/source/includes/_invoice.md
@@ -877,7 +877,7 @@ invoiceApi.get_invoice_as_html(invoice_id, api_key, api_secret)
 
 > Example Response:
 
-```
+```text/plain
 <html>
     <head>
         <style type="text/css">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -245,11 +245,11 @@ under the License.
               $(element).show();
             }
             
-            $(element).has('.json, .textplain, .xml').show();
+            $(element).has('.json, .textplain, .plaintext, .xml').show();
             
             $(element).children('.highlight').each(function (index, ch) {
               $(ch).hide()
-              $(ch).has(`.${activeLang}, .json, .textplain, .xml`).show()
+              $(ch).has(`.${activeLang}, .json, .textplain, .plaintext, .xml`).show()
             })
           });
         }


### PR DESCRIPTION
Missing Example Response in https://killbill.github.io/slate/invoice.html#render-an-invoice-as-html