### PR TITLE
Fix custom field id in Ruby code examples

### DIFF
--- a/source/includes/_account.md
+++ b/source/includes/_account.md
@@ -3957,7 +3957,7 @@ accountApi.deleteAccountCustomFields(accountId,
 ```
 
 ```ruby
-custom_field_id = custom_field.id
+custom_field_id = custom_field.custom_field_id
 
 account.remove_custom_field(custom_field_id, 
                             user, 

--- a/source/includes/_invoice-payment.md
+++ b/source/includes/_invoice-payment.md
@@ -770,7 +770,7 @@ invoicePaymentApi.deleteInvoicePaymentCustomFields(paymentId,
 ```
 
 ```ruby
-custom_field_id = custom_field.id
+custom_field_id = custom_field.custom_field_id
 
 invoice_payment.remove_custom_field(custom_field_id,                                                                                            
                                     user, 

--- a/source/includes/_payment.md
+++ b/source/includes/_payment.md
@@ -1751,7 +1751,7 @@ paymentApi.deletePaymentCustomFields(paymentId,
 ```
 
 ```ruby
-custom_field_id = custom_field.id
+custom_field_id = custom_field.custom_field_id
 
 payment.remove_custom_field(custom_field_id,                                                                                            
                             user, 


### PR DESCRIPTION
Ruby code examples are using `custom_field.id`, but [KB's Ruby client exposes custom fields' id with `custom_field_id`](https://github.com/killbill/killbill-client-ruby/blob/0c897c2006f5a8e22bbc98176e91200ff02253cd/lib/killbill_client/models/gen/custom_field_attributes.rb#L31).