### PR TITLE
Update retrieve api doc

### DIFF
--- a/source/includes/_invoice.md
+++ b/source/includes/_invoice.md
@@ -704,9 +704,11 @@ Invoice invoiceWithItems = invoiceApi.getInvoice(invoiceId,
 
 ```ruby
 invoice_id = "5c6083c1-a673-4b67-9b86-74139df50448"
+with_children_items = false
 audit = 'NONE'
 
 invoice = KillBillClient::Model::Invoice.find_by_id(invoice_id,
+                                          with_children_items,
                                           audit,
                                           options)
 ```
@@ -838,9 +840,11 @@ Invoice invoiceByNumber = invoiceApi.getInvoiceByNumber(invoiceNumber,
 
 ```ruby
 invoice_number = "7318"
+with_children_items = false
 audit = 'NONE'
 
 invoice = KillBillClient::Model::Invoice.find_by_number(invoice_number,
+                                              with_children_items,
                                               audit,
                                               options)
 ```
@@ -2591,12 +2595,14 @@ comment = nil
 invoice = KillBillClient::Model::Invoice.new
 invoice.invoice_id = '7bf0f3d6-4ffb-4d5a-98c7-1158083432d0'
 
+custom_fields = []
 custom_field = KillBillClient::Model::CustomFieldAttributes.new
 custom_field.object_type = 'INVOICE'
 custom_field.name = 'Test Custom Field'
 custom_field.value = 'test_value'
+custom_fields.push custom_field
 
-invoice.add_custom_field(custom_field,
+invoice.add_custom_field(custom_fields,
                          user,
                          reason,
                          comment,
@@ -2803,11 +2809,13 @@ comment = nil
 invoice = KillBillClient::Model::Invoice.new
 invoice.invoice_id = '7bf0f3d6-4ffb-4d5a-98c7-1158083432d0'
 
+custom_fields = []
 custom_field = KillBillClient::Model::CustomFieldAttributes.new
 custom_field.custom_field_id = 'ec53d741-e52a-4860-a6d3-03bb22b24a90'
 custom_field.value = 'new value'
+custom_fields.push custom_field
 
-invoice.modify_custom_field(custom_field,
+invoice.modify_custom_field(custom_fields,
                             user,
                             reason,
                             comment,
@@ -2919,9 +2927,11 @@ comment = nil
 invoice = KillBillClient::Model::Invoice.new
 invoice.invoice_id = '7bf0f3d6-4ffb-4d5a-98c7-1158083432d0'
 
+custom_field_ids = []
 custom_field_id = 'ec53d741-e52a-4860-a6d3-03bb22b24a90'
+custom_field_ids.push custom_field_id
 
-invoice.remove_custom_field(custom_field_id,
+invoice.remove_custom_field(custom_field_ids,
                             user,
                             reason,
                             comment,

--- a/source/includes/_payment-method.md
+++ b/source/includes/_payment-method.md
@@ -75,11 +75,17 @@ PaymentMethod paymentMethod = paymentMethodApi.getPaymentMethod(paymentMethodId,
 
 ```ruby
 payment_method_id = "6a0bf13e-d57f-4f79-84bd-3690135f1923"
+included_deleted = false
 with_plugin_info = false
+audit = "NONE"
+plugin_property = ["property"]
 
 payment_method = KillBillClient::Model::PaymentMethod.find_by_id(payment_method_id,
-                                                with_plugin_info,
-                                                options)
+                                                                 included_deleted,
+                                                                 with_plugin_info,
+                                                                 plugin_property,
+                                                                 audit,
+                                                                 options)
 ```
 
 ```python
@@ -322,11 +328,13 @@ PaymentMethod paymentMethod = paymentMethodApi.getPaymentMethodByKey(externalKey
 payment_method_key = "sample_external_key"
 included_deleted = false
 with_plugin_info = false
+plugin_property = ['property']
 audit = 'NONE'
 
 payment_method = KillBillClient::Model::PaymentMethod.find_by_external_key(payment_method_key,
                                                           included_deleted,
                                                           with_plugin_info,
+                                                          plugin_property,
                                                           audit,
                                                           options)
 ```
@@ -787,11 +795,13 @@ comment = nil
 payment_method = KillBillClient::Model::PaymentMethod.new
 payment_method.payment_method_id = "06e5c871-3caf-41c2-9d7e-30c95f6e309c"
 
+custom_fields = []
 custom_field = KillBillClient::Model::CustomFieldAttributes.new
 custom_field.name = 'Test Custom Field'
 custom_field.value = 'test_value'
+custom_fields.push custom_field
 
-payment_method.add_custom_field(custom_field,
+payment_method.add_custom_field(custom_fields,
                                 user,
                                 reason,
                                 comment,
@@ -1004,10 +1014,12 @@ comment = nil
 payment_method = KillBillClient::Model::PaymentMethod.new
 payment_method.payment_method_id = "06e5c871-3caf-41c2-9d7e-30c95f6e309c"
 
+custom_fields = []
 custom_field.custom_field_id = '7fb3dde7-0911-4477-99e3-69d142509bb9'
 custom_field.value = 'new value'
+custom_fields.push custom_field
 
-payment_method.modify_custom_field(custom_field,
+payment_method.modify_custom_field(custom_fields,
                                    user,
                                    reason,
                                    comment,
@@ -1115,9 +1127,11 @@ comment = nil
 payment_method = KillBillClient::Model::PaymentMethod.new
 payment_method.payment_method_id = "06e5c871-3caf-41c2-9d7e-30c95f6e309c"
 
+custom_field_ids = []
 custom_field_id = 'cda969c3-1092-4702-b155-05d0ef899fa2'
+custom_field_ids.push custom_field_id
 
-payment_method.remove_custom_field(custom_field_id,
+payment_method.remove_custom_field(custom_field_ids,
                                    user,
                                    reason,
                                    comment,

--- a/source/includes/_payment-transaction.md
+++ b/source/includes/_payment-transaction.md
@@ -79,10 +79,12 @@ Payment payment = paymentTransactionApi.getPaymentByTransactionId(paymentTransac
 
 ```ruby
 payment_transaction_id = "e5f000f7-0733-4828-a887-3a4a58d27596"
-with_plugin_info = false
 with_attempts = false
+with_plugin_info = false
+plugin_property = ['property']
+audit = "NONE"
 
-payment = KillBillClient::Model::Payment.find_by_transaction_id(payment_transaction_id, with_plugin_info, with_attempts, options)
+payment = KillBillClient::Model::Payment.find_by_transaction_id(payment_transaction_id, with_attempts, with_plugin_info, plugin_property, audit, options)
 ```
 
 ```python
@@ -203,9 +205,10 @@ Payment payment = paymentTransactionApi.getPaymentByTransactionExternalKey(trans
 external_key = "e5f000f7-0733-4828-a887-3a4a58d27596"
 with_plugin_info = false
 with_attempts = false
+plugin_property = ["property"]
 audit = 'NONE'
 
-payment = KillBillClient::Model::Payment.find_by_transaction_external_key(external_key, with_plugin_info, with_attempts, audit, options)
+payment = KillBillClient::Model::Payment.find_by_transaction_external_key(external_key, with_plugin_info, with_attempts, plugin_property, audit, options)
 ```
 
 ```python
@@ -598,11 +601,13 @@ comment = nil
 payment_transaction = KillBillClient::Model::Transaction.new
 payment_transaction.transaction_id = "e5f000f7-0733-4828-a887-3a4a58d27596"
 
+custom_fields = []
 custom_field = KillBillClient::Model::CustomFieldAttributes.new
 custom_field.name = 'Test Custom Field'
 custom_field.value = 'test_value'
+custom_fields.push custom_field
 
-payment_transaction.add_custom_field(custom_field,
+payment_transaction.add_custom_field(custom_fields,
                                 user,
                                 reason,
                                 comment,
@@ -805,11 +810,14 @@ comment = nil
 payment_transaction = KillBillClient::Model::Transaction.new
 payment_transaction.transaction_id = "e5f000f7-0733-4828-a887-3a4a58d27596"
 
+custom_fields = []
+custom_field = KillBillClient::Model::CustomFieldAttributes.new
 custom_field.custom_field_id = '7fb3dde7-0911-4477-99e3-69d142509bb9'
 custom_field.name = 'Test Modify'
 custom_field.value = 'test_modify_value'
+custom_fields.push custom_field
 
-payment_transaction.modify_custom_field(custom_field,
+payment_transaction.modify_custom_field(custom_fields,
                                    user,
                                    reason,
                                    comment,
@@ -915,9 +923,10 @@ comment = nil
 payment_transaction = KillBillClient::Model::Transaction.new
 payment_transaction.transaction_id = "e5f000f7-0733-4828-a887-3a4a58d27596"
 
+custom_field_ids = []
 custom_field_id = 'cda969c3-1092-4702-b155-05d0ef899fa2'
-
-payment_transaction.remove_custom_field(custom_field_id,
+custom_field_ids.push custom_field_id
+payment_transaction.remove_custom_field(custom_field_ids,
                                    user,
                                    reason,
                                    comment,

--- a/source/includes/_subscription.md
+++ b/source/includes/_subscription.md
@@ -945,8 +945,9 @@ Subscription subscription = subscriptionApi.getSubscription(subscriptionId,
 
 ```ruby
 subscription_id = "161692a4-c293-410c-a92f-939c5e3dcba7"
+audit = "NONE"
 
-subscription = KillBillClient::Model::Subscription.find_by_id(subscription_id, options)
+subscription = KillBillClient::Model::Subscription.find_by_id(subscription_id, audit, options)
 ```
 
 ```python
@@ -1109,7 +1110,8 @@ Subscription subscription = subscriptionApi.getSubscriptionByKey(externalKey, re
 
 ```ruby
 external_key = "somethingSpecial"
-subscription = KillBillClient::Model::Subscription.find_by_external_key(external_key, options)
+audit = "NONE"
+subscription = KillBillClient::Model::Subscription.find_by_external_key(external_key, audit, options)
 ```
 
 ```python
@@ -2146,11 +2148,12 @@ comment = nil
 subscription = KillBillClient::Model::Subscription.new
 subscription.subscription_id = "2207150d-0652-43eb-abbe-2cbd0092b744"
 
+custom_fields = []
 custom_field = KillBillClient::Model::CustomFieldAttributes.new
 custom_field.name = 'Test Custom Field'
 custom_field.value = 'test_value'
-
-subscription.add_custom_field(custom_field,
+custom_fields.push custom_field
+subscription.add_custom_field(custom_fields,
                               user,
                               reason,
                               comment,
@@ -2360,11 +2363,13 @@ comment = nil
 subscription = KillBillClient::Model::Subscription.new
 subscription.subscription_id = "2207150d-0652-43eb-abbe-2cbd0092b744"
 
+custom_fields = []
 custom_field = KillBillClient::Model::CustomFieldAttributes.new
 custom_field.custom_field_id = 'a04adaca-78a4-41fe-b512-a8d620aad456'
 custom_field.value = 'test_modify_value'
+custom_fields.push custom_field
 
-subscription.modify_custom_field(custom_field,
+subscription.modify_custom_field(custom_fields,
                                  user,
                                  reason,
                                  comment,
@@ -2472,9 +2477,11 @@ comment = nil
 subscription = KillBillClient::Model::Subscription.new
 subscription.subscription_id = "2207150d-0652-43eb-abbe-2cbd0092b744"
 
+custom_field_ids = []
 custom_field_id = 'a04adaca-78a4-41fe-b512-a8d620aad456'
+custom_field_ids.push custom_field_id
 
-subscription.remove_custom_field(custom_field_id,
+subscription.remove_custom_field(custom_field_ids,
                                  user,
                                  reason,
                                  comment,


### PR DESCRIPTION
Related tickets: https://github.com/killbill/killbill-client-ruby/issues/89
Updated:
- The Retrieve Subscription by Id accepts a AUDIT but this is not present in the Ruby code and needs to be added.
- The Retrieve Subscription by Key accepts a AUDIT query parameter but this is not present in the Ruby code and needs to be added.
- The Retrieve Payment Method by Id accepts an AUDIT query parameter/ pluginProperties query parameter but this is not present in the Ruby code and needs to be added.
- The Retrieve Payment Method by Key accepts an AUDIT / pluginProperties query parameter but this is not present in the Ruby code and needs to be added.
- The Retrieve Payment by Transaction Id accepts an AUDIT / pluginProperties query parameter but this is not present in the Ruby code and needs to be added.
- The Retrieve Payment by Transaction Key accepts an AUDIT / pluginProperties query parameter but this is not present in the Ruby code and needs to be added.
- Retrieve Invoice By Id - This endpoint accepts a query parameter called withChildrenItems. However the corresponding Ruby method does not accept this parameter and needs to be updated.
- Retrieve Invoice By Number - This endpoint accepts a query parameter called withChildrenItems. However the corresponding Ruby method does not accept this parameter and needs to be updated.

