### PR TITLE
Multiple invoice tags API

### DIFF
--- a/source/includes/_invoice.md
+++ b/source/includes/_invoice.md
@@ -3036,9 +3036,9 @@ comment = nil
 invoice = KillBillClient::Model::Invoice.new
 invoice.invoice_id = '7bf0f3d6-4ffb-4d5a-98c7-1158083432d0'
 
-tag_name = 'WRITTEN_OFF'
+tag_definition_ids = ['2c1f8309-24d7-437c-971b-7e68ff2d393a']
 
-invoice.add_tag(tag_name,
+invoice.add_tags_from_definition_ids(tag_definition_ids,
                user,
                reason,
                comment,
@@ -3235,9 +3235,9 @@ comment = nil
 invoice = KillBillClient::Model::Invoice.new
 invoice.invoice_id = '7bf0f3d6-4ffb-4d5a-98c7-1158083432d0'
 
-tag_name = 'WRITTEN_OFF'
+tag_definition_ids = ['2c1f8309-24d7-437c-971b-7e68ff2d393a']
 
-invoice.remove_tag(tag_name,
+invoice.remove_tags_from_definition_ids(tag_definition_ids,
                   user,
                   reason,
                   comment,


### PR DESCRIPTION
Related_ticket: https://github.com/killbill/killbill-client-ruby/issues/89
Updates:

- Add multiple tags to the Invoice
- Remove multiple tags