### PR TITLE
Update generate invoice dry run API

### DIFF
--- a/source/includes/_invoice.md
+++ b/source/includes/_invoice.md
@@ -1832,12 +1832,20 @@ Invoice dryRunInvoice = invoiceApi.generateDryRunInvoice(dryRunArg,
 # to see what is the next invoice that the system will generate for this account 
 # 
 account_id = "5527abbc-d83d-447f-bf3d-ab9542ea631e"
+user = nil
+reason = nil
+comment = nil
 target_date = nil
 upcoming_invoice_target_date = true
+plugin_properties = ["key%3Dvalue"]
 
 KillBillClient::Model::Invoice.trigger_invoice_dry_run(account_id, 
                                                        target_date, 
-                                                       upcoming_invoice_target_date, 
+                                                       upcoming_invoice_target_date,
+                                                       plugin_properties,
+                                                       user,
+                                                       reason,
+                                                       comment,
                                                        options)
 ```
 


### PR DESCRIPTION
Related ticket: https://github.com/killbill/killbill-client-ruby/issues/89
Update:
Generate Invoice Dry Run - The Ruby code for this endpoint does not accept the reason, comment parameters. I think this is required.
