### PR TITLE
Update Ruby transaction complete api

### DIFF
--- a/source/includes/_payment.md
+++ b/source/includes/_payment.md
@@ -485,11 +485,11 @@ transaction            = KillBillClient::Model::Transaction.new
 transaction.payment_id = "7dcda896-808b-414c-aad4-74ddc98e3dcb"
 refresh_options        = nil
 
-transaction.complete_initial_transaction(user, 
-                                         reason, 
-                                         comment, 
-                                         options, 
-                                         refresh_options)
+transaction.complete(user,
+                     reason,
+                     comment,
+                     options,
+                     refresh_options)
 ```
 
 ```python
@@ -563,11 +563,11 @@ transaction                      = KillBillClient::Model::Transaction.new
 transaction.payment_external_key = "example_payment_external_key"
 refresh_options                  = nil
 
-transaction.complete_initial_transaction(user, 
-                                         reason, 
-                                         comment, 
-                                         options, 
-                                         refresh_options)
+transaction.complete(user,
+                     reason,
+                     comment,
+                     options,
+                     refresh_options)
 ```
 
 ```python


### PR DESCRIPTION
Related issue: https://github.com/orgs/killbill/projects/22/views/1?pane=issue&itemId=53996249 
Update:
- [Complete existing transaction using payment external key](https://killbill.github.io/slate/payment.html#complete-an-existing-transaction-using-paymentexternalkey) - This API endpoint allows completing an existing transaction using the payment external key ( without payment ID ). However, the Ruby code errors out, though the transaction gets updated correctly.
- [Void existing transaction using payment external key](https://killbill.github.io/slate/payment.html#void-an-existing-payment-using-paymentexternalkey) - This API endpoint allows to void an existing transaction using the payment external key ( without payment ID ). However, the Ruby code errors out, though the transaction gets updated correctly.