### PR TITLE
Issue 88 Add new Role Apis

### DIFF
--- a/source/includes/_security.md
+++ b/source/includes/_security.md
@@ -708,6 +708,11 @@ RoleDefinition roleDefinition = securityApi.getRoleDefinition(role, requestOptio
 
 
 ```ruby
+
+role = 'TestRole'
+
+roleDef = KillBillClient::Model::RoleDefinition.find_by_name(role, options)
+
 ```
 
 ```python
@@ -893,6 +898,16 @@ securityApi.updateRoleDefinition(roleDefinition, requestOptions);
 ```
 
 ```ruby
+user = 'user'
+reason = 'reason'
+comment = 'comment'
+
+roleDef = KillBillClient::Model::RoleDefinition.new
+
+roleDef.role = 'TestRole'
+roleDef.permissions = ["account:*", "invoice:trigger"]
+
+roleDef.update(user,reason,comment,options)
 ```
 
 ```python


### PR DESCRIPTION
Related issue: https://github.com/killbill/killbill-client-ruby/issues/88
- Update an existing role permissions
- Retrieve Role definition