### PR TITLE
Include `accountId` parameter in catalog endpoints

### DIFF
--- a/source/includes/_catalog.md
+++ b/source/includes/_catalog.md
@@ -446,9 +446,10 @@ $catalogXml = $apiInstance->getCatalogXml();
 
 **Query Parameters**
 
-| Name | Type | Required | Default | Description |
-| ---- | -----| -------- | ------- | ----------- |
-| **requestedDate** | string | false | current date | requested date |
+| Name              | Type   | Required | Default      | Description                                                                                                                   |
+|-------------------|--------| -------- |--------------|-------------------------------------------------------------------------------------------------------------------------------|
+| **requestedDate** | string | false | current date | requested date                                                                                                                |
+| **accountId**     | UUID   | false | none         | Account Id for which to fetch the catalog (applicable only in case of catalog plugins)|
 
 **Response**
 
@@ -681,6 +682,7 @@ $catalogJson = $apiInstance->getCatalogJson();
 | Name | Type | Required | Default | Description |
 | ---- | -----| -------- | ------- | ----------- |
 | **requestedDate** | string | false | current date | requested date |
+| **accountId**     | UUID   | false | none         | Account Id for which to fetch the catalog (applicable only in case of catalog plugins). |
 
 **Response**
 
@@ -747,7 +749,9 @@ $catalogVersions = $apiInstance->getCatalogVersions();
 
 **Query Parameters**
 
-None.
+| Name | Type | Required | Default | Description |
+| ---- | -----| -------- | ------- | ----------- |
+| **accountId**     | UUID   | false | none         | Account Id for which to fetch the catalog (applicable only in case of catalog plugins).|
 
 **Response**
 
@@ -849,8 +853,9 @@ $availableBasePlans = $apiInstance->getAvailableBasePlans();
 
 **Query Parameters**
 
-None.
-
+| Name | Type | Required | Default | Description |
+| ---- | -----| -------- | ------- | ----------- |
+| **accountId**     | UUID   | false | none         | Account Id for which to fetch the catalog (applicable only in case of catalog plugins). |
 **Response**
 
 If successful, returns a status code of 200 and a list of objects representing the available base products and plans.
@@ -943,6 +948,7 @@ $availableAddOns = $apiInstance->getAvailableAddons($baseProductName);
 | ---- | -----| -------- | ------- | ----------- |
 | **baseProductName** | string | true | none | base product name |
 | **priceListName** | string | false | all price lists | price list name |
+| **accountId**     | UUID   | false | none         | Account Id for which to fetch the catalog (applicable only in case of catalog plugins). |
 
 **Response**
 

--- a/source/includes/_payment-method.md
+++ b/source/includes/_payment-method.md
@@ -277,7 +277,6 @@ $result = $apiInstance->getPaymentMethod($paymentMethodId, $includedDeleted, $wi
 |-----------------------------|-------------------|----------|---------|----------------------------------------------------------------------------------|
 | **includedDeleted**         | boolean           | no       | false   | If true, include deleted payment methods                                         |
 | **withPluginInfo**          | boolean           | no       | false   | If true, include plugin details (see below)                                      |
-| account should be invoiced) |                   |          |         |                                                                                  |
 | **pluginProperty**          | array of strings	 | no       | omit    | list of plugin properties, if any. Should be in the format `key%3Dvalue`         |
 | **audit**                   | string            | no       | "NONE"  | Level of audit information to return:"NONE", "MINIMAL" (only inserts), or "FULL" |
 


### PR DESCRIPTION
Added `accountId` parameter in catalog endpoints 
Deleted unnecessary row in the query parameters table for the [Retrieve payment method by Id](https://killbill.github.io/slate/payment-method.html#retrieve-a-payment-method-by-id) endpoint