### PR TITLE
Add a purple dot for aviate API pages

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -115,6 +115,9 @@ under the License.
               <li>
                 <a href="<%= menu_item[:href]%>" class="site-navigator__item site-navigator__menu-item" data-title="<%= menu_item[:title] %>">
                   <span><%= menu_item[:content] %></span>
+                  <% if menu_item[:title].downcase.match("aviate") %>
+                    <span class="dot" style="background-color: #7C3AE3;"></span>
+                  <% end %>
                 </a>
                 
                 <% if menu_item[:children].length > 0 %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -608,7 +608,6 @@ body.dark {
     }
 
     &>span {
-      flex-grow: 1;
       overflow-x: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
@@ -1039,3 +1038,19 @@ body.dark {
     padding: 24px;
   }
 }
+
+.dot {
+  flex-shrink: 0;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: inherit;
+  margin-left: 5px;
+  line-height: 0; /* Override any inherited line-height */
+  padding: 0;
+  vertical-align: middle;
+  position: relative; /* Isolate from surrounding layout */
+  overflow: hidden; /* Prevent parent influence on size */
+}
+


### PR DESCRIPTION
Experimental PR to add a purple dot. Me and ChatGPT collaborated on this project - mostly I iterated on lots of suggestion from the brain, and tweaked things until I got something that **seems** to work. The **seem* part is the one that worries me...

<img width="338" alt="Screenshot 2024-12-08 at 2 14 06 PM" src="https://github.com/user-attachments/assets/1310ffff-caad-45af-b9e7-08c26c9e39cd">

